### PR TITLE
`generate()`: Create a `.gitignore` that ignores `*.pem`, `*.pub`, and `/build/`

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -124,6 +124,7 @@ function generate(
         """
         *.pem
         *.pub
+        /build/
         """,
     )
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -119,4 +119,11 @@ function generate(
         PackageBundler.instantiate(joinpath(@__DIR__, "environments"))
         """,
     )
+    write(
+        joinpath(directory, ".gitignore"),
+        """
+        *.pem
+        *.pub
+        """,
+    )
 end


### PR DESCRIPTION
I imagine that some people will be checking these PackageBundler projects into source control. We definitely don't want to check the private key into source control, and probably we don't want to check the public key into source control either.

So let's auto-generate a `.gitignore` file that ignores the public and private keys.