### PR TITLE
Add a hint to the "config file not found" error message

### DIFF
--- a/src/PackageBundler.jl
+++ b/src/PackageBundler.jl
@@ -113,7 +113,7 @@ function bundle(
 )
     config = abspath(config)
     endswith(config, ".toml") || error("Config file must be a TOML file: `$config`.")
-    isfile(config) || error("Config file not found: `$config`.")
+    isfile(config) || error("Config file not found: `$config`. Is your current working directory the correct directory?")
 
     dir = dirname(config)
 


### PR DESCRIPTION
I'm not sure if this PR is necessary.

I ran into this error because my current working directory wasn't correct. I was in the `environments` subdirectory, but I needed to be in the top-level directory.